### PR TITLE
Handle lower-case and title-case headers consistently

### DIFF
--- a/src/ring/middleware/gzip.clj
+++ b/src/ring/middleware/gzip.clj
@@ -20,16 +20,16 @@
 ;; Set Vary to make sure proxies don't deliver the wrong content.
 (defn- set-response-headers
   [headers]
-  (if-let [vary (get headers "vary")]
+  (if-let [vary (or (get headers "vary") (get headers "Vary"))]
     (-> headers
       (assoc "Vary" (str vary ", Accept-Encoding"))
       (assoc "Content-Encoding" "gzip")
-      (dissoc "Content-Length")
+      (dissoc "Content-Length" "content-length")
       (dissoc "vary"))
     (-> headers
       (assoc "Vary" "Accept-Encoding")
       (assoc "Content-Encoding" "gzip")
-      (dissoc "Content-Length"))))
+      (dissoc "Content-Length" "content-length"))))
 
 (def ^:private supported-status? #{200, 201, 202, 203, 204, 205 403, 404})
 
@@ -45,7 +45,7 @@
     (or (string? body)
         (seq? body)
         (instance? InputStream body)
-        (and (instance? File body) 
+        (and (instance? File body)
              (re-seq #"(?i)\.(htm|html|css|js|json|xml)" (pr-str body))))))
 
 (def ^:private min-length 859)

--- a/test/ring/middleware/gzip_test.clj
+++ b/test/ring/middleware/gzip_test.clj
@@ -81,10 +81,30 @@
                         req (req :headers {"accept-encoding" "gzip"})
                         resp ((wrap-gzip handler) req)]
                     (is (= (get-in resp [:headers "Vary"])
-                           "Accept-Language, Accept-Encoding"))
-                    (is (= (get-in resp [:headers "Content-Encoding"])
-                           "gzip"))
-                    (is (= (get-in resp [:headers "Content Length"]) nil))))
+                           "Accept-Language, Accept-Encoding")))
+                  (let [handler (constantly {:status 200
+                                             :headers {"Vary" "Accept-Language"}
+                                             :body long-string})
+                        req (req :headers {"accept-encoding" "gzip"})
+                        resp ((wrap-gzip handler) req)]
+                    (is (= (get-in resp [:headers "Vary"])
+                           "Accept-Language, Accept-Encoding"))))
+
+         (testing "response-headers-with-existing-content-length"
+                  (let [handler (constantly {:status 200
+                                             :headers {"content-length" (count long-string)}
+                                             :body long-string})
+                        req (req :headers {"accept-encoding" "gzip"})
+                        resp ((wrap-gzip handler) req)]
+                    (is (= (get-in resp [:headers "content-length"])
+                           nil)))
+                  (let [handler (constantly {:status 200
+                                             :headers {"Content-Length" (count long-string)}
+                                             :body long-string})
+                        req (req :headers {"accept-encoding" "gzip"})
+                        resp ((wrap-gzip handler) req)]
+                    (is (= (get-in resp [:headers "Content-Length"])
+                           nil))))
 
          (testing "supported-statuses"
                   (doseq [status [200, 201, 202, 203, 204, 205, 403, 404]


### PR DESCRIPTION
This change relates to the handling of case in set-response-headers here:

https://github.com/bertrandk/ring-gzip/blob/7aa1945af5527026772f0e7d77ec9b7c1270ba08/src/ring/middleware/gzip.clj#L21

The function is currently a little inconsistent with header case. It only works correctly if the incoming `vary` header uses the lower-case header name (as it only get's the key `vary`), but also it requires that the incoming `Content-Length` header uses the title-case name (as it only dissoc's the key `Content-Length`).

This change ensures that vary and content-length are handled correctly, whether the lower-case or title-case is used.

The way to solve this definitively would be to do case-insensitive lookups on these keys (a case-insensitive map) but this seems like a more costly change. This PR attempts to at least make the behaviour consistent and should accommodate all practical uses of the middleware.

Thanks for the library btw, a very thorough and clean implementation. Cheers!
