### PR TITLE
default the status to 200 when checking if gzip encoding is possible

### DIFF
--- a/src/ring/middleware/gzip.clj
+++ b/src/ring/middleware/gzip.clj
@@ -62,7 +62,7 @@
 (defn- supported-response?
   [resp]
   (let [{:keys [status headers]} resp]
-    (and (supported-status? status)
+    (and (supported-status? (or status 200))
          (unencoded-type? headers)
          (supported-type? resp)
          (supported-size? resp))))


### PR DESCRIPTION
To my best knowledge, if no status is provided, Ring assumes it is 200 (at least with ring-jetty-adapter).