### PR TITLE
check for capitalized "Content-Encoding" header

### DIFF
--- a/src/ring/middleware/gzip.clj
+++ b/src/ring/middleware/gzip.clj
@@ -35,7 +35,7 @@
 
 (defn- unencoded-type?
   [headers]
-  (if (headers "content-encoding")
+  (if (or (headers "Content-Encoding") (headers "content-encoding"))
     false
     true))
 

--- a/test/ring/middleware/gzip_test.clj
+++ b/test/ring/middleware/gzip_test.clj
@@ -132,6 +132,14 @@
                         req (req :headers {"accept-encoding" "deflate, gzip"})
                         resp ((wrap-gzip handler) req)]
                     (is (not= (get-in resp [:headers "Content-Encoding"])
+                              "gzip")))
+                  (let [handler (constantly {:status 200
+                                             :headers {"Content-Encoding"
+                                                       "deflate"}
+                                             :body long-string})
+                        req (req :headers {"accept-encoding" "deflate, gzip"})
+                        resp ((wrap-gzip handler) req)]
+                    (is (not= (get-in resp [:headers "Content-Encoding"])
                               "gzip"))))
 
          (testing "small-response-size"


### PR DESCRIPTION
In the same spirit as #2, this PR adds a check for the capitalized version of the "Content-Encoding" header. A funny consequence of the old behavior was that the wrap-gzip middleware did not compose with itself - specifying wrap-gzip twice in ring middleware could cause responses to be double gzipped.