### PR TITLE
Allow vector as Acceps header (allowed in ring spec).

### DIFF
--- a/src/ring/middleware/gzip.clj
+++ b/src/ring/middleware/gzip.clj
@@ -13,9 +13,10 @@
   (if-let [accepts (get-in req [:headers "accept-encoding"])]
     ;; Be aggressive in supporting clients with mangled headers (due to
     ;; proxies, av software, buggy browsers, etc...)
-    (re-seq
-      #"(gzip\s*,?\s*(gzip|deflate)?|X{4,13}|~{4,13}|\-{4,13})"
-      accepts)))
+    (not-empty
+      (for [a (if (coll? accepts) accepts [accepts])
+            :when (re-seq #"(gzip\s*,?\s*(gzip|deflate)?|X{4,13}|~{4,13}|\-{4,13})" a)]
+        true))))
 
 ;; Set Vary to make sure proxies don't deliver the wrong content.
 (defn- set-response-headers


### PR DESCRIPTION
Hi,

This patch fixes problem with handling multiple Accept headers. Ring spec states that multiple headers are represented as vectors, thus accepts-gzip? function was throwing ClassCastException in some situations. Note that HTTP spec states that multiple header values can be represented as comma-separated string, so some Ring compatible web servers may split such headers and then pass them to ring handler as vectors.

Regards,
rle
