### PR TITLE
Check for nil headers

### DIFF
--- a/src/ring/middleware/gzip.clj
+++ b/src/ring/middleware/gzip.clj
@@ -35,7 +35,8 @@
 
 (defn- unencoded-type?
   [headers]
-  (if (or (headers "Content-Encoding") (headers "content-encoding"))
+  (if (and headers
+           (or (headers "Content-Encoding") (headers "content-encoding")))
     false
     true))
 


### PR DESCRIPTION
It is technically possible to return nil headers from a Ring response which will result in a NPE without this change.